### PR TITLE
feat: Add 'mens' to menu categories

### DIFF
--- a/convex/types.ts
+++ b/convex/types.ts
@@ -307,6 +307,7 @@ export type StaffWithInvitationStatus = {
 export const MENU_CATEGORY_VALUES = [
   '人気メニュー',
   'カット',
+  'メンズ',
   'カラー',
   'パーマ',
   'トリートメント',


### PR DESCRIPTION
This commit adds 'メンズ' (mens) to the `MENU_CATEGORY_VALUES` constant in `convex/types.ts` to allow setting this category when registering menus.